### PR TITLE
pipe_error_fix

### DIFF
--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -6,7 +6,7 @@
 /*   By: seungcoh <seungcoh@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/12 15:02:07 by jeunjeon          #+#    #+#             */
-/*   Updated: 2022/02/17 11:47:44 by seungcoh         ###   ########.fr       */
+/*   Updated: 2022/02/18 17:36:22 by seungcoh         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -187,8 +187,8 @@ int	minishell(t_mini *mini)
 				*/
 			ft_command(mini, argv);
 		}
-		if (((t_argv *)head->content)->is_pipe) // is_stream이 true이면 | 이므로 다음 argv가 존재할때 was_pipe=1로
-			((t_argv *)head->next->content)->was_pipe = 1;
+		if (argv->is_pipe && head->next->next) // is_stream이 true이면 | 이므로 다음 argv가 존재할때 was_pipe=1로
+			((t_argv *)head->next->next->content)->was_pipe = 1;
 		else if (((t_argv *)head->content)->is_and)
 		{
 			//printf("exit:%d\n", g_exit_state);


### PR DESCRIPTION
echo aa | cat과 같은 기본 pipe가 안되는 것을 수정
하지만 exit이 나오면서 강제 종료됨
하위 버전들에서 pipe 고쳐서 실행 했을 때는 강제종료 되지 않는 것을 보니 중간 단계 수정에서 뭔가 잘못된 것으로 추청

추가로 테스터기 몇 개 돌려봤는데 결과가 정상적으로 안나와서 결과 확인이 힘드네요 exit(127)로 종료되는 것을 디버깅해서 확인해도 테스터기에서는 1로 종료했다고 하는 문제 등이 있습니다.

과카몰리에서 돌렸을때는 rl함수에서 컴파일에러가 나는데 readline 설치해도 발생해서 문제를 해결하지 못했습니다.